### PR TITLE
Fix resume pagination handling and data extraction

### DIFF
--- a/actions/resumes_actions/click_resumes.py
+++ b/actions/resumes_actions/click_resumes.py
@@ -1,19 +1,20 @@
 import time
 
-from helpers.highlights import highlight_blocks
 from selenium.common import TimeoutException, NoSuchElementException
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support import expected_conditions as EC
 
 from actions.resumes_actions.dataframe import build_dataframe, save_dataframe
 from actions.resumes_actions.find_resumes import find_resumes
 from actions.resumes_actions.parse_resume import parse_resume
 from actions.resumes_actions.setup_search import setup_search
 from configs.config import config
-from selenium.webdriver.support import expected_conditions as EC
-from selenium.webdriver.common.by import By
+from helpers.highlights import highlight_blocks
 
 
 def click_resumes():
     setup_search()
+    config.resume_records = []
 
     has_next_page = True
 
@@ -26,10 +27,10 @@ def click_resumes():
         for resume in resumes_list:
             try:
                 apply_button = resume.find_element(By.XPATH, './/a[@data-qa="serp-item__title"]')
-                highlight_blocks([apply_button])   # лучше всегда передавать список
-                resume_links.append(apply_button.get_attribute('href'))
-            except Exception as e:
-                print(f"Не удалось найти ссылку в карточке: {e}")
+                highlight_blocks(apply_button)
+                resume_links.append(apply_button.get_attribute("href"))
+            except Exception as error:
+                print(f"Не удалось найти ссылку в карточке: {error}")
 
         for link in resume_links:
             config.driver.execute_script("window.open(arguments[0], '_blank');", link)
@@ -37,6 +38,9 @@ def click_resumes():
 
             try:
                 resume_data = parse_resume()
+            except Exception as error:
+                print(f"Не удалось распарсить резюме: {error}")
+            else:
                 config.resume_records.append(resume_data)
                 print(resume_data)
                 print(f"Добавлено резюме: {resume_data.get('full_name', 'Неизвестно')}")
@@ -55,27 +59,36 @@ def click_resumes():
         print("Не удалось собрать данные по резюме.")
 
 
-
 def go_to_next_page():
     try:
         next_button = config.driver.find_element(By.XPATH, '//a[@data-qa="pager-next"]')
     except NoSuchElementException:
+        print("Кнопка перехода на следующую страницу не найдена.")
         return False
 
-    classes = (next_button.get_attribute('class') or '').lower()
-    if 'disabled' in classes:
+    classes = (next_button.get_attribute("class") or "").lower()
+    if "disabled" in classes:
+        print("Достигнута последняя страница выдачи.")
         return False
 
+    current_url = config.driver.current_url
     config.driver.execute_script("arguments[0].click()", next_button)
+
     try:
-        config.wait.until(EC.staleness_of(next_button))
+        config.wait.until(EC.url_changes(current_url))
+    except TimeoutException:
+        if config.driver.current_url == current_url:
+            print("Не удалось перейти на следующую страницу.")
+            return False
+
+    try:
         config.wait.until(
             EC.presence_of_all_elements_located(
                 (By.XPATH, '//div[contains(@data-qa, "resume-serp__resume") and @data-resume-id]')
             )
         )
     except TimeoutException:
-        return False
+        print("Новые резюме не загрузились вовремя, пробуем продолжить.")
 
     time.sleep(1)
     return True

--- a/actions/resumes_actions/dataframe.py
+++ b/actions/resumes_actions/dataframe.py
@@ -1,6 +1,7 @@
 from pathlib import Path
-import pandas as pd
 from typing import Iterable, Mapping
+
+import pandas as pd
 
 
 def build_dataframe(records: Iterable[Mapping[str, str]] | None) -> pd.DataFrame:

--- a/actions/resumes_actions/find_resumes.py
+++ b/actions/resumes_actions/find_resumes.py
@@ -1,5 +1,6 @@
-from configs.config import config
 from selenium.webdriver.common.by import By
+
+from configs.config import config
 from helpers.highlights import highlight_blocks
 
 

--- a/actions/resumes_actions/parse_resume.py
+++ b/actions/resumes_actions/parse_resume.py
@@ -2,28 +2,28 @@ from urllib.parse import urlparse
 
 from selenium.common.exceptions import NoSuchElementException
 from selenium.webdriver.common.by import By
-from selenium.webdriver.support import expected_conditions as EC
 
 from configs.config import config
 
 
 def parse_resume():
     resume_data = {
-        'resume_id': extract_resume_id(config.driver.current_url),
-        'url': config.driver.current_url,
-        'desired_position': safe_get_text(By.XPATH, '//span[@data-qa="resume-block-title-position"]'),
-        'salary': safe_get_text(By.XPATH, '//span[@data-qa="resume-block-salary"]'),
-        'age': safe_get_text(By.XPATH, '//span[@data-qa="resume-personal-age"]'),
-        'gender': safe_get_text(By.XPATH, '//span[@data-qa="resume-personal-gender"]'),
-        'location': safe_get_text(By.XPATH, '//span[@data-qa="resume-personal-address"]'),
-        'work_experience': safe_get_text(By.XPATH, '//div[@data-qa="resume-block-experience"]'),
-        'education': safe_get_text(By.XPATH, '//div[@data-qa="resume-block-education"]'),
-        'languages': safe_join_texts(By.XPATH, '//span[@data-qa="resume-block-language-item"]'),
-        'skills': safe_join_texts(By.XPATH, '//span[@data-qa="skills-table-item"]'),
-        'citizenship': safe_join_texts(By.XPATH, '//span[@data-qa="resume-personal-citizenship"]'),
-        'ready_to_relocate': safe_get_text(By.XPATH, '//p[@data-qa="resume-personal-relocation"]'),
-        'travel_time': safe_get_text(By.XPATH, '//span[@data-qa="resume-personal-metro"]'),
-        'updated_at': safe_get_text(By.XPATH, '//span[@data-qa="resume-updatedAt"]'),
+        "resume_id": extract_resume_id(config.driver.current_url),
+        "url": config.driver.current_url,
+        "full_name": safe_get_text(By.XPATH, '//h1[@data-qa="resume-personal-name"]'),
+        "desired_position": safe_get_text(By.XPATH, '//span[@data-qa="resume-block-title-position"]'),
+        "salary": safe_get_text(By.XPATH, '//span[@data-qa="resume-block-salary"]'),
+        "age": safe_get_text(By.XPATH, '//span[@data-qa="resume-personal-age"]'),
+        "gender": safe_get_text(By.XPATH, '//span[@data-qa="resume-personal-gender"]'),
+        "location": safe_get_text(By.XPATH, '//span[@data-qa="resume-personal-address"]'),
+        "work_experience": safe_get_text(By.XPATH, '//div[@data-qa="resume-block-experience"]'),
+        "education": safe_get_text(By.XPATH, '//div[@data-qa="resume-block-education"]'),
+        "languages": safe_join_texts(By.XPATH, '//span[@data-qa="resume-block-language-item"]'),
+        "skills": safe_join_texts(By.XPATH, '//span[@data-qa="skills-table-item"]'),
+        "citizenship": safe_join_texts(By.XPATH, '//span[@data-qa="resume-personal-citizenship"]'),
+        "ready_to_relocate": safe_get_text(By.XPATH, '//p[@data-qa="resume-personal-relocation"]'),
+        "travel_time": safe_get_text(By.XPATH, '//span[@data-qa="resume-personal-metro"]'),
+        "updated_at": safe_get_text(By.XPATH, '//span[@data-qa="resume-updatedAt"]'),
     }
 
     return resume_data
@@ -32,16 +32,17 @@ def parse_resume():
 def safe_get_text(by, selector):
     try:
         element = config.driver.find_element(by, selector)
-        return element.text.strip()
     except NoSuchElementException:
-        return ''
+        return ""
+
+    return element.text.strip()
 
 
-def safe_join_texts(by, selector, separator=', '):
+def safe_join_texts(by, selector, separator=", "):
     try:
         elements = config.driver.find_elements(by, selector)
     except NoSuchElementException:
-        return ''
+        return ""
 
     values = [element.text.strip() for element in elements if element.text.strip()]
     return separator.join(values)
@@ -49,5 +50,5 @@ def safe_join_texts(by, selector, separator=', '):
 
 def extract_resume_id(url):
     parsed = urlparse(url)
-    resume_id = parsed.path.rstrip('/').split('/')[-1]
+    resume_id = parsed.path.rstrip("/").split("/")[-1]
     return resume_id

--- a/actions/resumes_actions/setup_search.py
+++ b/actions/resumes_actions/setup_search.py
@@ -1,15 +1,27 @@
-from configs.config import config
-from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.common.by import By
+from selenium.webdriver.support import expected_conditions as EC
 
+from configs.config import config
 from helpers.highlights import highlight_blocks
 
 
 def setup_search():
-    search_input= config.wait.until(EC.element_to_be_clickable((By.XPATH, '//input[@id="a11y-search-input"]')))
+    search_input = config.wait.until(
+        EC.element_to_be_clickable((By.XPATH, '//input[@id="a11y-search-input"]'))
+    )
     highlight_blocks(search_input)
-    config.driver.execute_script('arguments[0].value = arguments[1]', search_input, config.search_query)
 
-    #Click search button
-    advanced_search_apply_button = config.wait.until(EC.element_to_be_clickable((By.XPATH, '//button[@data-qa="search-button"]')))
-    config.driver.execute_script("arguments[0].click()", advanced_search_apply_button)
+    search_value = (config.search_query or "").strip()
+    config.driver.execute_script("arguments[0].value = arguments[1]", search_input, search_value)
+
+    search_button = config.wait.until(
+        EC.element_to_be_clickable((By.XPATH, '//button[@data-qa="search-button"]'))
+    )
+    highlight_blocks(search_button)
+    config.driver.execute_script("arguments[0].click()", search_button)
+
+    config.wait.until(
+        EC.presence_of_all_elements_located(
+            (By.XPATH, '//div[contains(@data-qa, "resume-serp__resume") and @data-resume-id]')
+        )
+    )

--- a/configs/config.py
+++ b/configs/config.py
@@ -1,7 +1,9 @@
 import os
+
 from dotenv import load_dotenv
 from selenium.webdriver import ActionChains
 from selenium.webdriver.support.wait import WebDriverWait
+
 from drivers.set_driver import set_driver
 
 load_dotenv()
@@ -17,17 +19,12 @@ class Config:
             cls._instance.wait_time = 10
             cls._instance.login_url = "https://hh.ru/account/login"
             cls._instance.base_page = "https://hh.ru"
-            cls._instance.driver_type = os.getenv("DRIVER").lower()
+            cls._instance.driver_type = os.getenv("DRIVER", "chrome").lower()
             cls._instance.driver = set_driver(cls._instance.driver_type)
             cls._instance.action = ActionChains(cls._instance.driver)
             cls._instance.wait = WebDriverWait(cls._instance.driver, cls._instance.wait_time)
-            #cls._instance.login_type = os.getenv("LOGIN_TYPE").lower()
-            #cls._instance.phone = os.getenv("PHONE")
-            #cls._instance.resume_id = os.getenv("RESUME_ID")
-            cls._instance.search_query = os.getenv("SEARCH_QUERY").lower()
-            #cls._instance.search_exclude = os.getenv("SEARCH_EXCLUDE").lower()
-            #cls._instance.region = os.getenv("REGION").lower()
-            #cls._instance.limit = int(os.getenv("LIMIT"))
+            cls._instance.search_query = os.getenv("SEARCH_QUERY", "")
+            cls._instance.limit = int(os.getenv("LIMIT", "0") or 0)
             cls._instance.resume_records = []
             cls._instance.output_path = os.getenv("OUTPUT_PATH", "data/resumes.csv")
 

--- a/drivers/use_chrome_driver.py
+++ b/drivers/use_chrome_driver.py
@@ -6,13 +6,13 @@ def use_chrome_driver():
     chromedriver_autoinstaller.install()
     options = webdriver.ChromeOptions()
 
-    options.add_argument(r'--user-data-dir=C:\selenium_profile')
-    options.add_argument('--profile-directory=Default')
+    options.add_argument(r"--user-data-dir=C:\\selenium_profile")
+    options.add_argument("--profile-directory=Default")
 
     # Подавляем шумящие логи
-    options.add_argument('--log-level=3')
+    options.add_argument("--log-level=3")
     options.add_experimental_option("excludeSwitches", ["enable-logging", "enable-automation"])
-    options.add_experimental_option('useAutomationExtension', False)
+    options.add_experimental_option("useAutomationExtension", False)
 
     driver = webdriver.Chrome(options=options)
     driver.get("https://www.google.com")

--- a/helpers/highlights.py
+++ b/helpers/highlights.py
@@ -2,9 +2,15 @@ from configs.config import config
 
 
 def highlight_blocks(elements):
-    if not isinstance(elements, (list, tuple)):
-        elements = [elements]
+    if elements is None:
+        return
 
-    for element in elements:
+    if isinstance(elements, (list, tuple, set)):
+        iterable = elements
+    else:
+        iterable = [elements]
+
+    for element in iterable:
+        if element is None:
+            continue
         config.driver.execute_script("arguments[0].style.border='3px solid red';", element)
-

--- a/script.py
+++ b/script.py
@@ -12,7 +12,8 @@ def start_clicking_vacancies():
     login()
     set_advanced_search()
 
-    while config.counter < config.limit:
+    limit = getattr(config, "limit", 0)
+    while not limit or config.counter < limit:
         click_vacancies()
 
     config.driver.close()
@@ -23,12 +24,15 @@ def start_clicking_resumes():
     click_resumes()
 
 
-
 if __name__ == "__main__":
     if is_running_from_batch():
         os.system("cls")
 
-    config.driver.get("https://tyumen.hh.ru/search/resume")
-
-    #start_clicking_vacancies()
-    start_clicking_resumes()
+    try:
+        config.driver.get("https://tyumen.hh.ru/search/resume")
+        start_clicking_resumes()
+    finally:
+        try:
+            config.driver.quit()
+        except Exception:
+            pass


### PR DESCRIPTION
## Summary
- reset resume collection and harden parsing so each profile captures the full name and optional sections safely
- wait for the next page to load during resume pagination and keep scraping until the last page
- update search setup, config defaults, and helper utilities to make resume scraping more robust

## Testing
- python -m compileall actions/resumes_actions helpers configs drivers script.py

------
https://chatgpt.com/codex/tasks/task_e_68dbd8bd29ac832facf594e82fe3b307